### PR TITLE
Test BMI

### DIFF
--- a/snow/bmisnowf.f90
+++ b/snow/bmisnowf.f90
@@ -557,6 +557,15 @@ contains
     case("precipitation_mass_flux")
        var_units = "mm"
        bmi_status = BMI_SUCCESS
+    case("precipitation_mass_flux_adjust_factor")
+       var_units = "-"
+       bmi_status = BMI_SUCCESS
+    case("open_area_or_not")
+       var_units = "-"
+       bmi_status = BMI_SUCCESS
+    case("snow_class")
+       var_units = "-"
+       bmi_status = BMI_SUCCESS
     case default
        var_units = "-"
        bmi_status = BMI_FAILURE

--- a/snow/bmisnowf.f90
+++ b/snow/bmisnowf.f90
@@ -586,6 +586,12 @@ contains
     case("snowpack__initial_mass-per-volume_density")
        var_size = sizeof(self%model%OLD)         ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
+    case("open_area_or_not")
+       var_size = sizeof(self%model%IOPEN)
+       bmi_status = BMI_SUCCESS
+    case("snow_class")
+       var_size = sizeof(self%model%ICL)
+       bmi_status = BMI_SUCCESS
     case("snowpack__depth")
        var_size = sizeof(self%model%NEW)         ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS


### PR DESCRIPTION
This PR fixes two minor problems that were found when running the [bmi-tester](https://github.com/csdms/bmi-tester) over the Python BMI that wraps the ECSimpleSnow component.

* Added open_area_or_not and snow_class cases to `get_var_itemsize` method
* Added open_area_or_not, snow_class, and precipitation_mass_flux_adjust_factor cases to `get_var_units` method

All tests in this repo still pass, and with these changes, the wrapped Python BMI passes the bmi-tester.
