### PR TITLE
Use BMI v1.2

### DIFF
--- a/snow/bmi.f90
+++ b/snow/bmi.f90
@@ -1,4 +1,4 @@
-module bmif
+module bmif_1_2
 
   implicit none
 
@@ -466,4 +466,4 @@ module bmif
 
   end interface
 
-end module bmif
+end module bmif_1_2

--- a/snow/bmisnowf.f90
+++ b/snow/bmisnowf.f90
@@ -1,7 +1,7 @@
 module bmisnowf
 
   use snow_model
-  use bmif
+  use bmif_1_2
   use, intrinsic :: iso_c_binding, only: c_ptr, c_loc, c_f_pointer
   implicit none
 

--- a/snow/examples/conflicting_instances_ex.f90
+++ b/snow/examples/conflicting_instances_ex.f90
@@ -1,7 +1,7 @@
 ! Do two instances of bmi_heat conflict?
 program conflicting_instances_ex
 
-  use bmif, only: BMI_MAX_VAR_NAME
+  use bmif_1_2, only: BMI_MAX_VAR_NAME
   use bmisnowf
   use testing_helpers
   implicit none

--- a/snow/examples/get_value_ex.f90
+++ b/snow/examples/get_value_ex.f90
@@ -1,7 +1,7 @@
 ! Test the get_value, get_value_ptr, and get_value_at_indices functions.
 program get_value_ex
 
-  use bmif, only: BMI_MAX_VAR_NAME
+  use bmif_1_2, only: BMI_MAX_VAR_NAME
   use bmisnowf
   use testing_helpers
   implicit none

--- a/snow/examples/info_ex.f90
+++ b/snow/examples/info_ex.f90
@@ -1,7 +1,7 @@
 ! Test the basic info BMI methods.
 program info_test
 
-  use bmif
+  use bmif_1_2
   use bmisnowf
   implicit none
 

--- a/snow/examples/irf_ex.f90
+++ b/snow/examples/irf_ex.f90
@@ -1,7 +1,7 @@
 ! Test the lifecycle and time BMI methods.
 program irf_test
 
-  use bmif, only: BMI_MAX_UNITS_NAME
+  use bmif_1_2, only: BMI_MAX_UNITS_NAME
   use bmisnowf
   implicit none
 

--- a/snow/examples/set_value_ex.f90
+++ b/snow/examples/set_value_ex.f90
@@ -1,7 +1,7 @@
 ! Test the set_value and set_value_at_indices functions.
 program set_value_ex
 
-  use bmif, only: BMI_MAX_VAR_NAME
+  use bmif_1_2, only: BMI_MAX_VAR_NAME
   use bmisnowf
   use testing_helpers
   implicit none

--- a/snow/examples/vargrid_ex.f90
+++ b/snow/examples/vargrid_ex.f90
@@ -1,7 +1,7 @@
 ! Test the BMI get_var_* and get_grid_* functions.
 program vargrid_test
 
-  use bmif, only: BMI_MAX_VAR_NAME
+  use bmif_1_2, only: BMI_MAX_VAR_NAME
   use bmisnowf
   implicit none
 

--- a/snow/tests/test_finalize.f90
+++ b/snow/tests/test_finalize.f90
@@ -1,6 +1,6 @@
 program test_finalize
 
-  use bmif, only: BMI_SUCCESS, BMI_FAILURE
+  use bmif_1_2, only: BMI_SUCCESS, BMI_FAILURE
   use bmisnowf
   use fixtures, only: status, config_file
 

--- a/snow/tests/test_get_component_name.f90
+++ b/snow/tests/test_get_component_name.f90
@@ -1,6 +1,6 @@
 program test_get_component_name
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_COMPONENT_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_COMPONENT_NAME
   use bmisnowf
   use fixtures, only: status
 

--- a/snow/tests/test_get_current_time.f90
+++ b/snow/tests/test_get_current_time.f90
@@ -1,6 +1,6 @@
 program test_get_current_time
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_get_end_time.f90
+++ b/snow/tests/test_get_end_time.f90
@@ -1,6 +1,6 @@
 program test_get_end_time
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_get_grid_rank.f90
+++ b/snow/tests/test_get_grid_rank.f90
@@ -1,6 +1,6 @@
 program test_get_grid_rank
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_get_grid_shape.f90
+++ b/snow/tests/test_get_grid_shape.f90
@@ -1,6 +1,6 @@
 program test_get_grid_shape
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_get_grid_size.f90
+++ b/snow/tests/test_get_grid_size.f90
@@ -1,6 +1,6 @@
 program test_get_grid_size
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_get_grid_type.f90
+++ b/snow/tests/test_get_grid_type.f90
@@ -1,6 +1,6 @@
 program test_get_grid_type
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_TYPE_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_TYPE_NAME
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_get_input_var_names.f90
+++ b/snow/tests/test_get_input_var_names.f90
@@ -1,6 +1,6 @@
 program test_get_input_var_names
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_VAR_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_VAR_NAME
   use bmisnowf
   use fixtures, only: status
 

--- a/snow/tests/test_get_output_var_names.f90
+++ b/snow/tests/test_get_output_var_names.f90
@@ -1,6 +1,6 @@
 program test_get_output_var_names
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_VAR_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_VAR_NAME
   use bmisnowf
   use fixtures, only: status
 

--- a/snow/tests/test_get_start_time.f90
+++ b/snow/tests/test_get_start_time.f90
@@ -1,6 +1,6 @@
 program test_get_start_time
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_get_time_step.f90
+++ b/snow/tests/test_get_time_step.f90
@@ -1,6 +1,6 @@
 program test_get_time_step
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_get_time_units.f90
+++ b/snow/tests/test_get_time_units.f90
@@ -1,6 +1,6 @@
 program test_get_time_units
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_UNITS_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_UNITS_NAME
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_get_value.f90
+++ b/snow/tests/test_get_value.f90
@@ -1,6 +1,6 @@
 program test_get_value
 
-  use bmif, only: BMI_SUCCESS, BMI_FAILURE
+  use bmif_1_2, only: BMI_SUCCESS, BMI_FAILURE
   use bmisnowf
   use fixtures, only: status, print_array
 

--- a/snow/tests/test_get_var_type.f90
+++ b/snow/tests/test_get_var_type.f90
@@ -1,6 +1,6 @@
 program test_get_var_type
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_TYPE_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_TYPE_NAME
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_get_var_units.f90
+++ b/snow/tests/test_get_var_units.f90
@@ -1,6 +1,6 @@
 program test_get_var_units
 
-  use bmif, only: BMI_FAILURE, BMI_MAX_UNITS_NAME
+  use bmif_1_2, only: BMI_FAILURE, BMI_MAX_UNITS_NAME
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_initialize.f90
+++ b/snow/tests/test_initialize.f90
@@ -1,6 +1,6 @@
 program test_initialize
 
-  use bmif, only: BMI_SUCCESS
+  use bmif_1_2, only: BMI_SUCCESS
   use bmisnowf
   use fixtures, only: status
 

--- a/snow/tests/test_set_value.f90
+++ b/snow/tests/test_set_value.f90
@@ -1,6 +1,6 @@
 program test_set_value
 
-  use bmif, only: BMI_SUCCESS, BMI_FAILURE
+  use bmif_1_2, only: BMI_SUCCESS, BMI_FAILURE
   use bmisnowf
   use fixtures, only: status, print_array
 

--- a/snow/tests/test_update.f90
+++ b/snow/tests/test_update.f90
@@ -1,6 +1,6 @@
 program test_update
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_update_frac.f90
+++ b/snow/tests/test_update_frac.f90
@@ -1,6 +1,6 @@
 program test_update_frac
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmisnowf
   use fixtures, only: config_file, status
 

--- a/snow/tests/test_update_until.f90
+++ b/snow/tests/test_update_until.f90
@@ -1,6 +1,6 @@
 program test_update_until
 
-  use bmif, only: BMI_FAILURE
+  use bmif_1_2, only: BMI_FAILURE
   use bmisnowf
   use fixtures, only: config_file, status
 


### PR DESCRIPTION
This PR updates the snow model to use Fortran BMI v1.2 instead of v1.1. The big change is that the name of the BMI module now includes the version. So, instead of

    use bmif

it's instead

    use bmif_1_2

There's very little change for the snow model BMI, but I hope it makes it clearer which BMI version is being used. There's more information at https://github.com/csdms/bmi-fortran/pull/36.