### PR TITLE
Build on Windows

### DIFF
--- a/snow/CMakeLists.txt
+++ b/snow/CMakeLists.txt
@@ -3,7 +3,12 @@ set(mod_name ${pkg_name})
 set(src_${pkg_name} functions.f main.f90)
 set(src_bmi${pkg_name} functions.f bmisnowf.f90 bmi.f90)
 
-add_library(${bmisnow_lib} SHARED ${src_bmi${pkg_name}})
+# Build a shared library, except on Windows.
+if(WIN32)
+  add_library(${bmisnow_lib} ${src_bmi${pkg_name}})
+else()
+  add_library(${bmisnow_lib} SHARED ${src_bmi${pkg_name}})
+endif()
 
 add_executable(run_${pkg_name} ${src_${pkg_name}})
 
@@ -11,17 +16,19 @@ add_executable(run_bmi${pkg_name} bmi_main.f90)
 target_link_libraries(run_bmi${pkg_name} ${bmisnow_lib})
 
 install(
-  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_${pkg_name}
-  DESTINATION bin
-  COMPONENT ${pkg_name})
+  TARGETS run_${pkg_name}
+  RUNTIME DESTINATION bin
+)
 install(
-  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_bmi${pkg_name}
-  DESTINATION bin
-  COMPONENT ${pkg_name})
+  TARGETS run_bmi${pkg_name}
+  RUNTIME DESTINATION bin
+)
 install(
   TARGETS ${bmisnow_lib}
-  DESTINATION lib
-  COMPONENT ${pkg_name})
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+)
 install(
   FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${mod_name}.mod
         ${CMAKE_Fortran_MODULE_DIRECTORY}/${bmisnow_lib}.mod


### PR DESCRIPTION
This PR updates the cmake build process so that ECSimpleSnow builds and runs on Windows.

To configure with cmake, run the following in a Developer Command Prompt

    mkdir _build && cd _build
    cmake .. ^
	  -G "NMake Makefiles" ^
	  -DCMAKE_INSTALL_PREFIX=[install_path] ^
	  -DCMAKE_BUILD_TYPE=Release

Note that the install path has to be an absolute path.

Then, to build and install:

    cmake --build . --target install --config Release

Run unit tests and examples of using the sample implementation with

    ctest

