### PR TITLE
Update CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,9 @@ project(bmisnow
     LANGUAGES Fortran
 )
 
-set(bmi_version 1.0)
 set(bmisnow_lib bmisnowf)
 set(data_dir ${CMAKE_SOURCE_DIR}/data)
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
-
-set(CMAKE_MACOSX_RPATH 1)
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
 add_subdirectory(snow)
 add_subdirectory(snow/tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ project(bmisnow
     LANGUAGES Fortran
 )
 
+include(GNUInstallDirs)
+
 set(bmisnow_lib bmisnowf)
 set(data_dir ${CMAKE_SOURCE_DIR}/data)
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
-cmake_minimum_required(VERSION 2.8)
+# ECSimpleSnow
+cmake_minimum_required(VERSION 3.12)
 
-project(bmisnow Fortran)
+project(bmisnow
+    VERSION 1.2.0
+    DESCRIPTION "A simple snow model with a Basic Model Interface"
+    HOMEPAGE_URL "https://permamodel.github.io"
+    LANGUAGES Fortran
+)
 
 set(bmi_version 1.0)
 set(bmisnow_lib bmisnowf)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ The outputs [**Daily**] are
 > `mkdir _build && cd _build`  
 > `cmake .. -DCMAKE_INSTALL_PREFIX=[install_path]`  
 > `make install`  
-> `source ../scripts/update_rpaths.sh`  
 > `ctest`
 
 **If you want to run the compiled BMI model:**

--- a/snow/CMakeLists.txt
+++ b/snow/CMakeLists.txt
@@ -1,6 +1,5 @@
 # ECSimplesnow: model
 set(pkg_name snow_model)
-set(mod_name ${pkg_name})
 set(src_${pkg_name} functions.f main.f90)
 set(src_bmi${pkg_name} functions.f bmisnowf.f90 bmi.f90)
 

--- a/snow/CMakeLists.txt
+++ b/snow/CMakeLists.txt
@@ -1,3 +1,4 @@
+# ECSimplesnow: model
 set(pkg_name snow_model)
 set(mod_name ${pkg_name})
 set(src_${pkg_name} functions.f main.f90)
@@ -17,19 +18,20 @@ target_link_libraries(run_bmi${pkg_name} ${bmisnow_lib})
 
 install(
   TARGETS run_${pkg_name}
-  RUNTIME DESTINATION bin
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 install(
   TARGETS run_bmi${pkg_name}
-  RUNTIME DESTINATION bin
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 install(
   TARGETS ${bmisnow_lib}
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 install(
-  FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${mod_name}.mod
+  FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${pkg_name}.mod
         ${CMAKE_Fortran_MODULE_DIRECTORY}/${bmisnow_lib}.mod
-  DESTINATION include)
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/snow/CMakeLists.txt
+++ b/snow/CMakeLists.txt
@@ -1,17 +1,14 @@
 # ECSimplesnow: model
 set(pkg_name snow_model)
-set(src_${pkg_name} functions.f main.f90)
-set(src_bmi${pkg_name} functions.f bmisnowf.f90 bmi.f90)
 
-# Build a shared library, except on Windows.
+add_library(snow OBJECT functions.f)
 if(WIN32)
-  add_library(${bmisnow_lib} ${src_bmi${pkg_name}})
+  add_library(${bmisnow_lib} STATIC bmisnowf.f90 bmi.f90 $<TARGET_OBJECTS:snow>)
 else()
-  add_library(${bmisnow_lib} SHARED ${src_bmi${pkg_name}})
+  add_library(${bmisnow_lib} SHARED bmisnowf.f90 bmi.f90 $<TARGET_OBJECTS:snow>)
 endif()
 
-add_executable(run_${pkg_name} ${src_${pkg_name}})
-
+add_executable(run_${pkg_name} main.f90 $<TARGET_OBJECTS:snow>)
 add_executable(run_bmi${pkg_name} bmi_main.f90)
 target_link_libraries(run_bmi${pkg_name} ${bmisnow_lib})
 

--- a/snow/examples/CMakeLists.txt
+++ b/snow/examples/CMakeLists.txt
@@ -1,12 +1,14 @@
+# ECSimpleSnow: examples
 include(CTest)
 
 include_directories(${CMAKE_Fortran_MODULE_DIRECTORY})
 
+add_library(helpers OBJECT testing_helpers.f90)
+
 function(make_example example_name)
   add_test(NAME ${example_name} COMMAND ${example_name})
-  set(src_${example_name} ${example_name}.f90 testing_helpers.f90)
-  add_executable(${example_name} ${src_${example_name}})
-  target_link_libraries(${example_name} ${bmi_lib} ${bmisnow_lib})
+  add_executable(${example_name} ${example_name}.f90 $<TARGET_OBJECTS:helpers>)
+  target_link_libraries(${example_name} ${bmisnow_lib})
 endfunction(make_example)
 
 make_example(info_ex)

--- a/snow/tests/CMakeLists.txt
+++ b/snow/tests/CMakeLists.txt
@@ -1,12 +1,14 @@
+# ECSimpleSnow: tests
 include(CTest)
 
 include_directories(${CMAKE_Fortran_MODULE_DIRECTORY})
 
+add_library(fixtures OBJECT fixtures.f90)
+
 function(make_test test_name)
   add_test(NAME ${test_name} COMMAND ${test_name})
-  set(src_${test_name} ${test_name}.f90 fixtures.f90)
-  add_executable(${test_name} ${src_${test_name}})
-  target_link_libraries(${test_name} ${bmi_lib} ${bmisnow_lib})
+  add_executable(${test_name} ${test_name}.f90 $<TARGET_OBJECTS:fixtures>)
+  target_link_libraries(${test_name} ${bmisnow_lib})
 endfunction(make_test)
 
 make_test(test_get_component_name)


### PR DESCRIPTION
This PR makes a few minor changes to the CMake-based build, including:

* Bumping up the minimum required CMake version
* Using standard GNU install directories
* Adding metadata to the project
* Using object libraries for source used in more than one target

This PR is modeled on https://github.com/permamodel/GIPL-BMI-Fortran/pull/9.